### PR TITLE
Re-adds missing Debug/Release cmake config and fixes Typos

### DIFF
--- a/cmake/Default.cmake
+++ b/cmake/Default.cmake
@@ -1,0 +1,65 @@
+################################################################################
+# Command for variable_watch. This command issues error message, if a variable
+# is changed. If variable PROPERTY_READER_GUARD_DISABLED is TRUE nothing happens
+#     variable_watch(<variable> property_reader_guard)
+################################################################################
+function(property_reader_guard VARIABLE ACCESS VALUE CURRENT_LIST_FILE STACK)
+    if("${PROPERTY_READER_GUARD_DISABLED}")
+        return()
+    endif()
+
+    if("${ACCESS}" STREQUAL "MODIFIED_ACCESS")
+        message(FATAL_ERROR
+            " Variable ${VARIABLE} is not supposed to be changed.\n"
+            " It is used only for reading target property ${VARIABLE}.\n"
+            " Use\n"
+            "     set_target_properties(\"<target>\" PROPERTIES \"${VARIABLE}\" \"<value>\")\n"
+            " or\n"
+            "     set_target_properties(\"<target>\" PROPERTIES \"${VARIABLE}_<CONFIG>\" \"<value>\")\n"
+            " instead.\n")
+    endif()
+endfunction()
+
+################################################################################
+# Create variable <name> with generator expression that expands to value of
+# target property <name>_<CONFIG>. If property is empty or not set then property
+# <name> is used instead. Variable <name> has watcher property_reader_guard that
+# doesn't allow to edit it.
+#     create_property_reader(<name>)
+# Input:
+#     name - Name of watched property and output variable
+################################################################################
+function(create_property_reader NAME)
+    set(PROPERTY_READER_GUARD_DISABLED TRUE)
+    set(CONFIG_VALUE "$<TARGET_GENEX_EVAL:${PROPS_TARGET},$<TARGET_PROPERTY:${PROPS_TARGET},${NAME}_$<UPPER_CASE:$<CONFIG>>>>")
+    set(IS_CONFIG_VALUE_EMPTY "$<STREQUAL:${CONFIG_VALUE},>")
+    set(GENERAL_VALUE "$<TARGET_GENEX_EVAL:${PROPS_TARGET},$<TARGET_PROPERTY:${PROPS_TARGET},${NAME}>>")
+    set("${NAME}" "$<IF:${IS_CONFIG_VALUE_EMPTY},${GENERAL_VALUE},${CONFIG_VALUE}>" PARENT_SCOPE)
+    variable_watch("${NAME}" property_reader_guard)
+endfunction()
+
+################################################################################
+# Set property $<name>_${PROPS_CONFIG_U} of ${PROPS_TARGET} to <value>
+#     set_config_specific_property(<name> <value>)
+# Input:
+#     name  - Prefix of property name
+#     value - New value
+################################################################################
+function(set_config_specific_property NAME VALUE)
+    set_target_properties("${PROPS_TARGET}" PROPERTIES "${NAME}_${PROPS_CONFIG_U}" "${VALUE}")
+endfunction()
+
+################################################################################
+
+create_property_reader("TARGET_NAME")
+create_property_reader("OUTPUT_DIRECTORY")
+
+set_config_specific_property("TARGET_NAME" "${PROPS_TARGET}")
+set_config_specific_property("OUTPUT_NAME" "${TARGET_NAME}")
+set_config_specific_property("ARCHIVE_OUTPUT_NAME" "${TARGET_NAME}")
+set_config_specific_property("LIBRARY_OUTPUT_NAME" "${TARGET_NAME}")
+set_config_specific_property("RUNTIME_OUTPUT_NAME" "${TARGET_NAME}")
+
+set_config_specific_property("ARCHIVE_OUTPUT_DIRECTORY" "${OUTPUT_DIRECTORY}")
+set_config_specific_property("LIBRARY_OUTPUT_DIRECTORY" "${OUTPUT_DIRECTORY}")
+set_config_specific_property("RUNTIME_OUTPUT_DIRECTORY" "${OUTPUT_DIRECTORY}")

--- a/cmake/DefaultCXX.cmake
+++ b/cmake/DefaultCXX.cmake
@@ -1,0 +1,12 @@
+include("${CMAKE_CURRENT_LIST_DIR}/Default.cmake")
+
+set_config_specific_property("OUTPUT_DIRECTORY" "${CMAKE_SOURCE_DIR}$<$<NOT:$<STREQUAL:${CMAKE_VS_PLATFORM_NAME},Win32>>:/${CMAKE_VS_PLATFORM_NAME}>/${PROPS_CONFIG}")
+
+if(MSVC)
+    create_property_reader("DEFAULT_CXX_EXCEPTION_HANDLING")
+    create_property_reader("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT")
+
+    # set_target_properties("${PROPS_TARGET}" PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    set_config_specific_property("DEFAULT_CXX_EXCEPTION_HANDLING" "/EHsc")
+    set_config_specific_property("DEFAULT_CXX_DEBUG_INFORMATION_FORMAT" "/Zi")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,10 @@ add_library(libultraship STATIC)
 set_property(TARGET libultraship PROPERTY CXX_STANDARD 20)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+use_props(${PROJECT_NAME} "${CMAKE_CONFIGURATION_TYPES}" "${DEFAULT_CXX_PROPS}")
+endif()
+
 #=================== Audio ===================
 
 set(Source_Files__Audio
@@ -375,7 +379,131 @@ else ()
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    target_compile_definitions(libultraship PRIVATE
-        ENABLE_DX11
-    )
+	if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
+		target_compile_definitions(${PROJECT_NAME} PRIVATE
+			"$<$<CONFIG:Debug>:"
+				"_DEBUG"
+			">"
+			"$<$<CONFIG:Release>:"
+				"NDEBUG"
+			">"
+			"SPDLOG_ACTIVE_LEVEL=0;"
+			"WIN32;"
+			"_CONSOLE;"
+			"_CRT_SECURE_NO_WARNINGS;"
+			"ENABLE_DX11;"
+			"ENABLE_OPENGL;"
+		)
+	elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
+		target_compile_definitions(${PROJECT_NAME} PRIVATE
+			"$<$<CONFIG:Debug>:"
+				"_DEBUG"
+			">"
+			"$<$<CONFIG:Release>:"
+				"NDEBUG"
+			">"
+			"SPDLOG_ACTIVE_LEVEL=0;"
+			"WIN32;"
+			"_CONSOLE;"
+			"_CRT_SECURE_NO_WARNINGS;"
+			"ENABLE_OPENGL;"
+			"ENABLE_DX11;"
+		)
+	endif()
+
+elseif (CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
+	target_compile_definitions(${PROJECT_NAME} PRIVATE
+            "$<$<CONFIG:Debug>:"
+                "_DEBUG"
+            ">"
+            "$<$<CONFIG:Release>:"
+                "NDEBUG"
+            ">"
+            "SPDLOG_ACTIVE_LEVEL=3;"
+            "SPDLOG_NO_THREAD_ID;"
+            "SPDLOG_NO_TLS;"
+            "STBI_NO_THREAD_LOCALS;"
+	)
+elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|AppleClang")
+	target_compile_definitions(${PROJECT_NAME} PRIVATE
+		"$<$<CONFIG:Debug>:"
+				"_DEBUG"
+			">"
+			"$<$<CONFIG:Release>:"
+				"NDEBUG"
+			">"
+			"ENABLE_OPENGL;"
+            "SPDLOG_ACTIVE_LEVEL=0;"
+	)
+endif()
+
+if(MSVC)
+    if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
+        target_compile_options(${PROJECT_NAME} PRIVATE
+            $<$<CONFIG:Debug>:
+                /Od;
+                /Oi-
+            >
+            $<$<CONFIG:Release>:
+                /std:c++latest;
+                /Oi;
+                /Gy
+            >
+            /permissive-;
+            /MP;
+            /sdl;
+            /W3;
+            ${DEFAULT_CXX_DEBUG_INFORMATION_FORMAT};
+            ${DEFAULT_CXX_EXCEPTION_HANDLING}
+        )
+    elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
+        target_compile_options(${PROJECT_NAME} PRIVATE
+            $<$<CONFIG:Debug>:
+                /Od;
+                /Oi-;
+                /W2
+            >
+            $<$<CONFIG:Release>:
+                /Oi;
+                /Gy;
+                /W3
+            >
+            /permissive-;
+            /MP;
+            /sdl;
+            ${DEFAULT_CXX_DEBUG_INFORMATION_FORMAT};
+            ${DEFAULT_CXX_EXCEPTION_HANDLING}
+        )
+    endif()
+    if("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
+        target_link_options(${PROJECT_NAME} PRIVATE
+            $<$<CONFIG:Release>:
+                /OPT:REF;
+                /OPT:ICF
+            >
+            /SUBSYSTEM:CONSOLE
+        )
+    elseif("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "Win32")
+        target_link_options(${PROJECT_NAME} PRIVATE
+            $<$<CONFIG:Release>:
+                /OPT:REF;
+                /OPT:ICF
+            >
+            /SUBSYSTEM:CONSOLE
+        )
+    endif()
+endif()
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	target_compile_options(${PROJECT_NAME} PRIVATE
+		-Wall
+		-Wextra
+		-Wno-error
+		-Wno-unused-variable
+		-Wno-unused-parameter
+		-Wno-unused-function
+		-Wno-parentheses
+		-Wno-narrowing
+		-Wno-missing-field-initializers
+	)
 endif()

--- a/src/controller/SDLController.cpp
+++ b/src/controller/SDLController.cpp
@@ -240,12 +240,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
             // Left stick
             if (posButton == BTN_STICKLEFT || posButton == BTN_STICKRIGHT) {
                 if (leftStickAxisX != SDL_CONTROLLER_AXIS_INVALID && leftStickAxisX != axis) {
-                    SPDLOG_TRACE("Invalid PosStickX configured. Neg was {} and Pos is {}", LStickAxisX, Axis);
+                    SPDLOG_TRACE("Invalid PosStickX configured. Neg was {} and Pos is {}", leftStickAxisX, axis);
                 }
 
                 if (leftStickDeadzone != 0 && leftStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone configured. Up/Down was {} and Left/Right is {}", LStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone configured. Up/Down was {} and Left/Right is {}", leftStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 leftStickDeadzone = axisDeadzone;
@@ -254,12 +254,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
 
             if (posButton == BTN_STICKUP || posButton == BTN_STICKDOWN) {
                 if (leftStickAxisY != SDL_CONTROLLER_AXIS_INVALID && leftStickAxisY != axis) {
-                    SPDLOG_TRACE("Invalid PosStickY configured. Neg was {} and Pos is {}", LStickAxisY, Axis);
+                    SPDLOG_TRACE("Invalid PosStickY configured. Neg was {} and Pos is {}", leftStickAxisY, axis);
                 }
 
                 if (leftStickDeadzone != 0 && leftStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", LStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", leftStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 leftStickDeadzone = axisDeadzone;
@@ -268,12 +268,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
 
             if (negButton == BTN_STICKLEFT || negButton == BTN_STICKRIGHT) {
                 if (leftStickAxisX != SDL_CONTROLLER_AXIS_INVALID && leftStickAxisX != axis) {
-                    SPDLOG_TRACE("Invalid NegStickX configured. Pos was {} and Neg is {}", LStickAxisX, Axis);
+                    SPDLOG_TRACE("Invalid NegStickX configured. Pos was {} and Neg is {}", leftStickAxisX, axis);
                 }
 
                 if (leftStickDeadzone != 0 && leftStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", LStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", leftStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 leftStickDeadzone = axisDeadzone;
@@ -282,12 +282,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
 
             if (negButton == BTN_STICKUP || negButton == BTN_STICKDOWN) {
                 if (leftStickAxisY != SDL_CONTROLLER_AXIS_INVALID && leftStickAxisY != axis) {
-                    SPDLOG_TRACE("Invalid NegStickY configured. Pos was {} and Neg is {}", LStickAxisY, Axis);
+                    SPDLOG_TRACE("Invalid NegStickY configured. Pos was {} and Neg is {}", leftStickAxisY, axis);
                 }
 
                 if (leftStickDeadzone != 0 && leftStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone misconfigured. Left/Right was {} and Up/Down is {}", LStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone misconfigured. Left/Right was {} and Up/Down is {}", leftStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 leftStickDeadzone = axisDeadzone;
@@ -297,12 +297,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
             // Right Stick
             if (posButton == BTN_VSTICKLEFT || posButton == BTN_VSTICKRIGHT) {
                 if (rightStickAxisX != SDL_CONTROLLER_AXIS_INVALID && rightStickAxisX != axis) {
-                    SPDLOG_TRACE("Invalid PosStickX configured. Neg was {} and Pos is {}", RStickAxisX, Axis);
+                    SPDLOG_TRACE("Invalid PosStickX configured. Neg was {} and Pos is {}", rightStickAxisX, axis);
                 }
 
                 if (rightStickDeadzone != 0 && rightStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone configured. Up/Down was {} and Left/Right is {}", RStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone configured. Up/Down was {} and Left/Right is {}", rightStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 rightStickDeadzone = axisDeadzone;
@@ -311,12 +311,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
 
             if (posButton == BTN_VSTICKUP || posButton == BTN_VSTICKDOWN) {
                 if (rightStickAxisY != SDL_CONTROLLER_AXIS_INVALID && rightStickAxisY != axis) {
-                    SPDLOG_TRACE("Invalid PosStickY configured. Neg was {} and Pos is {}", RStickAxisY, Axis);
+                    SPDLOG_TRACE("Invalid PosStickY configured. Neg was {} and Pos is {}", rightStickAxisY, axis);
                 }
 
                 if (rightStickDeadzone != 0 && rightStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", RStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", rightStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 rightStickDeadzone = axisDeadzone;
@@ -325,12 +325,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
 
             if (negButton == BTN_VSTICKLEFT || negButton == BTN_VSTICKRIGHT) {
                 if (rightStickAxisX != SDL_CONTROLLER_AXIS_INVALID && rightStickAxisX != axis) {
-                    SPDLOG_TRACE("Invalid NegStickX configured. Pos was {} and Neg is {}", RStickAxisX, Axis);
+                    SPDLOG_TRACE("Invalid NegStickX configured. Pos was {} and Neg is {}", rightStickAxisX, axis);
                 }
 
                 if (rightStickDeadzone != 0 && rightStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", RStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone configured. Left/Right was {} and Up/Down is {}", rightStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 rightStickDeadzone = axisDeadzone;
@@ -339,12 +339,12 @@ void SDLController::ReadFromSource(int32_t virtualSlot) {
 
             if (negButton == BTN_VSTICKUP || negButton == BTN_VSTICKDOWN) {
                 if (rightStickAxisY != SDL_CONTROLLER_AXIS_INVALID && rightStickAxisY != axis) {
-                    SPDLOG_TRACE("Invalid NegStickY configured. Pos was {} and Neg is {}", RStickAxisY, Axis);
+                    SPDLOG_TRACE("Invalid NegStickY configured. Pos was {} and Neg is {}", rightStickAxisY, axis);
                 }
 
                 if (rightStickDeadzone != 0 && rightStickDeadzone != axisDeadzone) {
-                    SPDLOG_TRACE("Invalid Deadzone misconfigured. Left/Right was {} and Up/Down is {}", RStickDeadzone,
-                                 AxisDeadzone);
+                    SPDLOG_TRACE("Invalid Deadzone misconfigured. Left/Right was {} and Up/Down is {}", rightStickDeadzone,
+                                 axisDeadzone);
                 }
 
                 rightStickDeadzone = axisDeadzone;

--- a/src/resource/Resource.cpp
+++ b/src/resource/Resource.cpp
@@ -48,7 +48,7 @@ Resource::~Resource() {
     Patches.clear();
 
     if (File != nullptr) {
-        SPDLOG_TRACE("Deconstructor called on file %s\n", file->path.c_str());
+        SPDLOG_TRACE("Deconstructor called on file %s\n", File->Path.c_str());
     }
 }
 } // namespace Ship

--- a/src/resource/ResourceMgr.cpp
+++ b/src/resource/ResourceMgr.cpp
@@ -105,7 +105,7 @@ void ResourceMgr::LoadFileThread() {
             mFileCache[toLoad->Path] = toLoad->IsLoaded && !toLoad->HasLoadError ? toLoad : nullptr;
         }
 
-        SPDLOG_TRACE("Loaded File {} on ResourceMgr thread", ToLoad->path);
+        SPDLOG_TRACE("Loaded File {} on ResourceMgr thread", toLoad->Path);
 
         toLoad->FileLoadNotifier.notify_all();
     }
@@ -151,7 +151,7 @@ void ResourceMgr::LoadResourceThread() {
                     toLoad->Res = resource;
                     mResourceCache[resource->File->Path] = resource;
 
-                    SPDLOG_TRACE("Loaded Resource {} on ResourceMgr thread", ToLoad->file->path);
+                    SPDLOG_TRACE("Loaded Resource {} on ResourceMgr thread", toLoad->File->Path);
 
                     resource->File = nullptr;
                 } else {
@@ -193,7 +193,7 @@ std::shared_ptr<OtrFile> ResourceMgr::LoadFileAsync(const std::string& filePath)
     // File NOT already loaded...?
     auto fileCacheFind = mFileCache.find(filePath);
     if (fileCacheFind == mFileCache.end()) {
-        SPDLOG_TRACE("Cache miss on File load: {}", FilePath.c_str());
+        SPDLOG_TRACE("Cache miss on File load: {}", filePath.c_str());
         std::shared_ptr<OtrFile> toLoad = std::make_shared<OtrFile>();
         toLoad->Path = filePath;
 
@@ -257,7 +257,7 @@ ResourceMgr::LoadResourceAsync(const char* filePath) {
     auto resCacheFind = mResourceCache.find(filePath);
     if (resCacheFind == mResourceCache.end() || resCacheFind->second->IsDirty /* || !FileData->IsLoaded*/) {
         if (resCacheFind == mResourceCache.end()) {
-            SPDLOG_TRACE("Cache miss on Resource load: {}", FilePath);
+            SPDLOG_TRACE("Cache miss on Resource load: {}", filePath);
         }
 
         std::shared_ptr<ResourcePromise> promise = std::make_shared<ResourcePromise>();


### PR DESCRIPTION
This re-enables debugging libultraship files on Windows. Also fixes some
typos that previously weren't being compiled due to the missing
Debug/Release configuration.